### PR TITLE
Implement sql.Scanner interface

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -246,6 +246,24 @@ func (u *UUID) UnmarshalBinary(data []byte) (err error) {
 	return
 }
 
+// Scan implements the sql.Scanner interface.
+// A 16-byte slice is handled by UnmarshalBinary, while
+// a longer byte slice or a string is handled by UnmarshalText.
+func (u *UUID) Scan(src interface{}) error {
+	switch src := src.(type) {
+	case []byte:
+		if len(src) == 16 {
+			return u.UnmarshalBinary(src)
+		}
+		return u.UnmarshalText(src)
+
+	case string:
+		return u.UnmarshalText([]byte(src))
+	}
+
+	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
 // FromBytes returns UUID converted from raw byte slice input.
 // It will return error if the slice isn't 16 bytes long.
 func FromBytes(input []byte) (u UUID, err error) {

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -261,6 +261,84 @@ func TestUnmarshalText(t *testing.T) {
 	}
 }
 
+func TestScanBinary(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	u1 := UUID{}
+	err := u1.Scan(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte{}
+	u2 := UUID{}
+
+	err = u2.Scan(b2)
+	if err == nil {
+		t.Errorf("Should return error unmarshalling from empty byte slice, got %s", err)
+	}
+}
+
+func TestScanString(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	u1 := UUID{}
+	err := u1.Scan(s1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	s2 := ""
+	u2 := UUID{}
+
+	err = u2.Scan(s2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+}
+
+func TestScanText(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.Scan(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte("")
+	u2 := UUID{}
+
+	err = u2.Scan(b2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+}
+
+func TestScanUnsupported(t *testing.T) {
+	u := UUID{}
+
+	err := u.Scan(true)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from bool")
+	}
+}
+
 func TestNewV1(t *testing.T) {
 	u := NewV1()
 


### PR DESCRIPTION
Uses `UnmarshalBinary` and `UnmarshalText` as discussed in #5. I think we can ignore [`driver.Valuer`](http://golang.org/pkg/database/sql/driver/#Valuer) for now since a user can call `.Bytes()` or `.String()` as appropriate.

Verified against PostgreSQL 9.3.5 with the following test:

```go
package main

import (
  "database/sql"
  "testing"

  _ "github.com/lib/pq"
  "github.com/satori/go.uuid"
)

func Test(t *testing.T) {
  db, _ := sql.Open("postgres", "host='/var/run/postgresql' sslmode='disable' dbname='gotest'")

  u1 := uuid.NewV4()
  u2 := uuid.UUID{}

  err := db.QueryRow(`SELECT $1::uuid`, u1.String()).Scan(&u2)
  if err != nil {
    t.Fatal(err)
  }

  if !uuid.Equal(u1, u2) {
    t.Errorf("Expected %v, got %v", u1, u2)
  }
}
```