### PR TITLE
Speed-up for string conversion function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ go:
     - 1.2
     - 1.3
     - 1.4
+sudo: false
 notifications:
     email: false

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -112,3 +112,10 @@ func BenchmarkUnmarshalText(b *testing.B) {
 		u.UnmarshalText(bytes)
 	}
 }
+
+func BenchmarkMarshalToString(b *testing.B) {
+	u := NewV4()
+	for i := 0; i < b.N; i++ {
+		u.String()
+	}
+}

--- a/uuid.go
+++ b/uuid.go
@@ -58,6 +58,9 @@ const (
 // UUID epoch (October 15, 1582) and Unix epoch (January 1, 1970).
 const epochStart = 122192928000000000
 
+// Used in string method conversion
+const dash byte = '-'
+
 // UUID v1/v2 storage.
 var (
 	storageMutex  sync.Mutex
@@ -174,8 +177,19 @@ func (u UUID) Bytes() []byte {
 // Returns canonical string representation of UUID:
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 func (u UUID) String() string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x",
-		u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = dash
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = dash
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = dash
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = dash
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
 }
 
 // SetVersion sets version bits.


### PR DESCRIPTION
Hi there,

Thank you for your package. Here's my small contribution to it.

```
go test -bench=. -benchmem -test.memprofilerate=1
PASS
....
BenchmarkMarshalToStringOld        50000             38808 ns/op             282 B/op         13 allocs/op
BenchmarkMarshalToString          500000              2503 ns/op              48 B/op          1 allocs/op
ok      github.com/satori/go.uuid       24.438s
```

```BenchmarkMarshalToStringOld``` refers to the old ```String()``` method and ```BenchmarkMarshalToString``` is the implementation in this PR.

Kind regards