### PR TITLE
Panic when getting entropy

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -64,6 +64,7 @@ const dash byte = '-'
 // UUID v1/v2 storage.
 var (
 	storageMutex  sync.Mutex
+	epochFunc     func() uint64 = unixTimeFunc
 	clockSequence uint16
 	lastTime      uint64
 	hardwareAddr  [6]byte
@@ -76,9 +77,6 @@ var (
 	urnPrefix  = []byte("urn:uuid:")
 	byteGroups = []int{8, 4, 4, 4, 12}
 )
-
-// Epoch calculation function
-var epochFunc func() uint64
 
 // Initialize storage
 func init() {
@@ -102,7 +100,6 @@ func init() {
 			}
 		}
 	}
-	epochFunc = unixTimeFunc
 }
 
 // Returns difference in 100-nanosecond intervals between


### PR DESCRIPTION
Panic when there is an error from `rand.Read` as discussed in #9. [Effective Go says its reasonable to panic during init.](https://golang.org/doc/effective_go.html#panic)

I moved the fallback MAC address to reduce the number of times a typical program would call `rand.Read`.