### PR TITLE
Add FromStringOrNil

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -306,6 +306,16 @@ func FromString(input string) (u UUID, err error) {
 	return
 }
 
+// FromStringOrNil returns UUID parsed from string input.
+// Same behavior as FromString, but returns a Nil UUID on error.
+func FromStringOrNil(input string) UUID {
+	uuid, err := FromString(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
 // Returns UUID v1/v2 storage state.
 // Returns epoch timestamp, clock sequence, and hardware address.
 func getStorage() (uint64, uint16, []byte) {

--- a/uuid.go
+++ b/uuid.go
@@ -299,6 +299,16 @@ func FromBytes(input []byte) (u UUID, err error) {
 	return
 }
 
+// FromBytesOrNil returns UUID converted from raw byte slice input.
+// Same behavior as FromBytes, but returns a Nil UUID on error.
+func FromBytesOrNil(input []byte) UUID {
+	uuid, err := FromBytes(input)
+	if err != nil {
+		return Nil
+	}
+	return uuid
+}
+
 // FromString returns UUID parsed from string input.
 // Input is expected in a form accepted by UnmarshalText.
 func FromString(input string) (u UUID, err error) {

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -224,6 +224,13 @@ func TestFromString(t *testing.T) {
 	}
 }
 
+func TestFromStringOrNil(t *testing.T) {
+	u := FromStringOrNil("")
+	if u != Nil {
+		t.Errorf("Should return Nil UUID on parse failure, got %s", u)
+	}
+}
+
 func TestMarshalText(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
 	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -231,6 +231,14 @@ func TestFromStringOrNil(t *testing.T) {
 	}
 }
 
+func TestFromBytesOrNil(t *testing.T) {
+	b := []byte{}
+	u := FromBytesOrNil(b)
+	if u != Nil {
+		t.Errorf("Should return Nil UUID on parse failure, got %s", u)
+	}
+}
+
 func TestMarshalText(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
 	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")


### PR DESCRIPTION
It's common to handle `Nil` UUIDs as default struct values. This function is useful for people like me that simply fall back to empty UUIDs on parse failure (when handling an HTTP request for example). For validation simply compare with `uuid.Nil`.