### PR TITLE
Add UUID V1 generation from a certain timestamp

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -23,6 +23,7 @@ package uuid
 
 import (
 	"testing"
+	"time"
 )
 
 func BenchmarkFromBytes(b *testing.B) {
@@ -56,6 +57,12 @@ func BenchmarkFromStringWithBrackets(b *testing.B) {
 func BenchmarkNewV1(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		NewV1()
+	}
+}
+
+func BenchmarkNewV1FromTime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		NewV1FromTime(time.Now())
 	}
 }
 

--- a/uuid.go
+++ b/uuid.go
@@ -66,10 +66,11 @@ const dash byte = '-'
 var (
 	storageMutex  sync.Mutex
 	storageOnce   sync.Once
-	epochFunc     = unixTimeFunc
+	epochFunc     = unixTimeNowFunc
 	clockSequence uint16
 	lastTime      uint64
 	hardwareAddr  [6]byte
+	emptyAddr     [6]byte
 	posixUID      = uint32(os.Getuid())
 	posixGID      = uint32(os.Getgid())
 )
@@ -119,8 +120,12 @@ func safeRandom(dest []byte) {
 // Returns difference in 100-nanosecond intervals between
 // UUID epoch (October 15, 1582) and current time.
 // This is default epoch calculation function.
-func unixTimeFunc() uint64 {
-	return epochStart + uint64(time.Now().UnixNano()/100)
+func unixTimeFunc(myTime time.Time) uint64 {
+	return epochStart + uint64(myTime.UnixNano()/100)
+}
+
+func unixTimeNowFunc() uint64 {
+	return unixTimeFunc(time.Now());
 }
 
 // UUID representation compliant with specification
@@ -363,6 +368,26 @@ func NewV1() UUID {
 	binary.BigEndian.PutUint16(u[8:], clockSeq)
 
 	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(1)
+	u.SetVariant()
+
+	return u
+}
+
+// NewV1FromTime returns UUID based on the specified timestamp and a constant MAC address.
+func NewV1FromTime(myTime time.Time) UUID {
+	u := UUID{}
+
+	timeNow := unixTimeFunc(myTime)
+	clockSeq := uint16(0)
+
+	binary.BigEndian.PutUint32(u[0:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[4:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint16(u[6:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	copy(u[10:], emptyAddr[:])
 
 	u.SetVersion(1)
 	u.SetVariant()

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -24,6 +24,7 @@ package uuid
 import (
 	"bytes"
 	"testing"
+	"time"
 )
 
 func TestBytes(t *testing.T) {
@@ -399,6 +400,26 @@ func TestNewV1(t *testing.T) {
 	}
 
 	epochFunc = oldFunc
+}
+
+func TestNewV1FromTime(t *testing.T) {
+	now := time.Now()
+	u := NewV1FromTime(now)
+
+	if u.Version() != 1 {
+		t.Errorf("UUIDv1 generated with incorrect version: %d", u.Version())
+	}
+
+	if u.Variant() != VariantRFC4122 {
+		t.Errorf("UUIDv1 generated with incorrect variant: %d", u.Variant())
+	}
+
+	u1 := NewV1FromTime(now)
+	u2 := NewV1FromTime(now)
+
+	if !Equal(u1, u2) {
+		t.Errorf("UUIDv1 generated two equal UUIDs: %s and %s", u1, u2)
+	}
 }
 
 func TestNewV2(t *testing.T) {


### PR DESCRIPTION
I've added this since I would like to have a way to generate a "constant" UUID v1 from a certain timestamp.