### PR TITLE
Fix UnmarshalText panic on invalid short uuid

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -227,30 +227,37 @@ func (u UUID) MarshalText() (text []byte, err error) {
 // "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 func (u *UUID) UnmarshalText(text []byte) (err error) {
 	if len(text) < 32 {
-		err = fmt.Errorf("uuid: invalid UUID string: %s", text)
+		err = fmt.Errorf("uuid: UUID string too short: %s", text)
 		return
 	}
 
-	if bytes.Equal(text[:9], urnPrefix) {
-		text = text[9:]
-	} else if text[0] == '{' {
-		text = text[1:]
+	t := text[:]
+
+	if bytes.Equal(t[:9], urnPrefix) {
+		t = t[9:]
+	} else if t[0] == '{' {
+		t = t[1:]
 	}
 
 	b := u[:]
 
 	for _, byteGroup := range byteGroups {
-		if text[0] == '-' {
-			text = text[1:]
+		if t[0] == '-' {
+			t = t[1:]
 		}
 
-		_, err = hex.Decode(b[:byteGroup/2], text[:byteGroup])
+		if len(t) < byteGroup {
+			err = fmt.Errorf("uuid: UUID string too short: %s", text)
+			return
+		}
+
+		_, err = hex.Decode(b[:byteGroup/2], t[:byteGroup])
 
 		if err != nil {
 			return
 		}
 
-		text = text[byteGroup:]
+		t = t[byteGroup:]
 		b = b[byteGroup/2:]
 	}
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -224,6 +224,18 @@ func TestFromString(t *testing.T) {
 	}
 }
 
+func TestFromStringShort(t *testing.T) {
+	// Invalid 35-character UUID string
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c"
+
+	for i := len(s1); i >= 0; i-- {
+		_, err := FromString(s1[:i])
+		if err == nil {
+			t.Errorf("Should return error trying to parse too short string, got %s", err)
+		}
+	}
+}
+
 func TestFromStringOrNil(t *testing.T) {
 	u := FromStringOrNil("")
 	if u != Nil {


### PR DESCRIPTION
Fixes satori/go.uuid#20. No longer panics on invalid UUID strings of certain length.

Includes tests for invalid short UUID strings