### PR TITLE
Interpret SQL NULL values as uuid.Nil

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -127,6 +127,13 @@ func unixTimeFunc() uint64 {
 // described in RFC 4122.
 type UUID [16]byte
 
+// NullUUID can be used with the standard sql package to represent a
+// UUID value that can be NULL in the database
+type NullUUID struct {
+	UUID  UUID
+	Valid bool
+}
+
 // The nil UUID is special form of UUID that is specified to have all
 // 128 bits set to zero.
 var Nil = UUID{}
@@ -303,6 +310,27 @@ func (u *UUID) Scan(src interface{}) error {
 	}
 
 	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
+}
+
+// Value implements the driver.Valuer interface.
+func (u NullUUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return u.UUID.Value()
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *NullUUID) Scan(src interface{}) error {
+	if src == nil {
+		u.UUID, u.Valid = Nil, false
+		return nil
+	}
+
+	// Delegate to UUID Scan function
+	u.Valid = true
+	return u.UUID.Scan(src)
 }
 
 // FromBytes returns UUID converted from raw byte slice input.

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -304,6 +304,32 @@ func TestValue(t *testing.T) {
 	}
 }
 
+func TestValueNil(t *testing.T) {
+	u := UUID{}
+
+	val, err := u.Value()
+	if err != nil {
+		t.Errorf("Error getting UUID value: %s", err)
+	}
+
+	if val != Nil.String() {
+		t.Errorf("Wrong value returned, should be equal to UUID.Nil: %s", val)
+	}
+}
+
+func TestNullUUIDValueNil(t *testing.T) {
+	u := NullUUID{}
+
+	val, err := u.Value()
+	if err != nil {
+		t.Errorf("Error getting UUID value: %s", err)
+	}
+
+	if val != nil {
+		t.Errorf("Wrong value returned, should be nil: %s", val)
+	}
+}
+
 func TestScanBinary(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
 	b1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
@@ -379,6 +405,51 @@ func TestScanUnsupported(t *testing.T) {
 	err := u.Scan(true)
 	if err == nil {
 		t.Errorf("Should return error trying to unmarshal from bool")
+	}
+}
+
+func TestScanNil(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	err := u.Scan(nil)
+	if err == nil {
+		t.Errorf("Error UUID shouldn't allow unmarshalling from nil")
+	}
+}
+
+func TestNullUUIDScanValid(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	u1 := NullUUID{}
+	err := u1.Scan(s1)
+	if err != nil {
+		t.Errorf("Error unmarshaling NullUUID: %s", err)
+	}
+
+	if !u1.Valid {
+		t.Errorf("NullUUID should be valid")
+	}
+
+	if !Equal(u, u1.UUID) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1.UUID)
+	}
+}
+
+func TestNullUUIDScanNil(t *testing.T) {
+	u := NullUUID{UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}, true}
+
+	err := u.Scan(nil)
+	if err != nil {
+		t.Errorf("Error unmarshaling NullUUID: %s", err)
+	}
+
+	if u.Valid {
+		t.Errorf("NullUUID should not be valid")
+	}
+
+	if !Equal(u.UUID, Nil) {
+		t.Errorf("NullUUID value should be equal to Nil: %s", u)
 	}
 }
 


### PR DESCRIPTION
When uuid stored in databases are `NULL`, the current Scan implementation refuses to convert them. This commit unmarshall `NULL` value to Nil.