### PR TITLE
json.marshaler and json.unmarshaler interface implementation

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -90,6 +90,13 @@ func BenchmarkMarshalBinary(b *testing.B) {
 	}
 }
 
+func BenchmarkMarshalJSON(b *testing.B) {
+	u := NewV4()
+	for i := 0; i < b.N; i++ {
+		u.MarshalJSON()
+	}
+}
+
 func BenchmarkMarshalText(b *testing.B) {
 	u := NewV4()
 	for i := 0; i < b.N; i++ {
@@ -102,6 +109,22 @@ func BenchmarkUnmarshalBinary(b *testing.B) {
 	u := UUID{}
 	for i := 0; i < b.N; i++ {
 		u.UnmarshalBinary(bytes)
+	}
+}
+
+func BenchmarkUnmarshalJSON1(b *testing.B) {
+	bytes := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	u := UUID{}
+	for i := 0; i < b.N; i++ {
+		u.UnmarshalJSON(bytes)
+	}
+}
+
+func BenchmarkUnmarshalJSON2(b *testing.B) {
+	bytes := []byte("\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"")
+	u := UUID{}
+	for i := 0; i < b.N; i++ {
+		u.UnmarshalJSON(bytes)
 	}
 }
 

--- a/uuid.go
+++ b/uuid.go
@@ -253,9 +253,13 @@ func (u *UUID) UnmarshalJSON(data []byte) (err error) {
 
 	t := data[:]
 
+	if t[0] == quotationMark {
+		t = t[1:]
+	}
+
 	if bytes.Equal(t[:9], urnPrefix) {
 		t = t[9:]
-	} else if t[0] == '{' || t[0] == '"' {
+	} else if t[0] == '{' {
 		t = t[1:]
 	}
 

--- a/uuid.go
+++ b/uuid.go
@@ -229,33 +229,33 @@ func (u UUID) MarshalText() (text []byte, err error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // It works the same as UnmarshalText except the quotation marks are removed if present.
-func (u *UUID) UnmarshalJSON(text []byte) (err error) {
-	if len(text) < 32 {
-		err = fmt.Errorf("uuid: invalid UUID string: %s", text)
+func (u *UUID) UnmarshalJSON(data []byte) (err error) {
+	if len(data) < 32 {
+		err = fmt.Errorf("uuid: invalid UUID string: %s", data)
 		return
 	}
 
-	if bytes.Equal(text[:9], urnPrefix) {
-		text = text[9:]
-	} else if text[0] == '{' {
-		text = text[1:]
-	} else if text[0] == '"' {
-		text = text[1:]
+	if bytes.Equal(data[:9], urnPrefix) {
+		data = data[9:]
+	} else if data[0] == '{' {
+		data = data[1:]
+	} else if data[0] == '"' {
+		data = data[1:]
 	}
 
 	b := u[:]
 	for _, byteGroup := range byteGroups {
-		if text[0] == '-' {
-			text = text[1:]
+		if data[0] == '-' {
+			data = data[1:]
 		}
 
-		_, err = hex.Decode(b[:byteGroup/2], text[:byteGroup])
+		_, err = hex.Decode(b[:byteGroup/2], data[:byteGroup])
 
 		if err != nil {
 			return
 		}
 
-		text = text[byteGroup:]
+		data = data[byteGroup:]
 		b = b[byteGroup/2:]
 	}
 

--- a/uuid.go
+++ b/uuid.go
@@ -60,7 +60,10 @@ const (
 const epochStart = 122192928000000000
 
 // Used in string method conversion
-const dash byte = '-'
+const (
+	dash byte = '-'
+	quotationMark byte = '"'
+)
 
 // UUID v1/v2 storage.
 var (
@@ -216,9 +219,20 @@ func (u *UUID) SetVariant() {
 // MarshalJSON implements the json.Marshaler interface.
 // The encoding is the same as returned by String except the quotation marks are added around.
 func (u UUID) MarshalJSON() (data []byte, err error) {
-	text := []byte(u.String())
-	data = append([]byte{'"'}, text...)
-	data = append(data, '"')
+	data = make([]byte, 38)
+
+	data[0] = quotationMark
+	hex.Encode(data[1:9], u[0:4])
+	data[9] = dash
+	hex.Encode(data[10:14], u[4:6])
+	data[14] = dash
+	hex.Encode(data[15:19], u[6:8])
+	data[19] = dash
+	hex.Encode(data[20:24], u[8:10])
+	data[24] = dash
+	hex.Encode(data[25:37], u[10:])
+	data[37] = quotationMark
+
 	return
 }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -283,11 +283,16 @@ func TestUnmarshalJSON(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
 	b0 := []byte("\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"")
 	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	b2 := []byte("\"{6ba7b810-9dad-11d1-80b4-00c04fd430c8}\"")
 
 	u1 := UUID{}
 	err := u1.UnmarshalJSON(b0)
 	if err != nil {
 		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
 	}
 
 	err = u1.UnmarshalJSON(b1)
@@ -299,10 +304,19 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
 	}
 
-	b2 := []byte("")
+	err = u1.UnmarshalJSON(b2)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b3 := []byte("")
 	u2 := UUID{}
 
-	err = u2.UnmarshalJSON(b2)
+	err = u2.UnmarshalJSON(b3)
 	if err == nil {
 		t.Errorf("Should return error trying to unmarshal from empty string")
 	}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -251,6 +251,20 @@ func TestFromBytesOrNil(t *testing.T) {
 	}
 }
 
+func TestMarshalJSON(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"")
+
+	b2, err := u.MarshalJSON()
+	if err != nil {
+		t.Errorf("Error marshaling UUID: %s", err)
+	}
+
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("Marshaled UUID should be %s, got %s", b1, b2)
+	}
+}
+
 func TestMarshalText(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
 	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
@@ -263,6 +277,36 @@ func TestMarshalText(t *testing.T) {
 	if !bytes.Equal(b1, b2) {
 		t.Errorf("Marshaled UUID should be %s, got %s", b1, b2)
 	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b0 := []byte("\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"")
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.UnmarshalJSON(b0)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	err = u1.UnmarshalJSON(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte("")
+	u2 := UUID{}
+
+	err = u2.UnmarshalJSON(b2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+
 }
 
 func TestUnmarshalText(t *testing.T) {


### PR DESCRIPTION
I added json.Marshaler and json.Unmarshaler interface implementation. 

The motivation behind this two methods were the problems when marshalling/un-marshalling UUID with ffjson. The default json marshaler works fine, it adds quotation marks around the UUID.String() value, but ffjson doesn't. 

So basically for marshalling I just added quotation marks around the result of String() method and for unmarshalling I check if the data[0] is a quotation mark then the first byte is thrown away.  

I also added the test for this two methods. If you think anything else is required please let me know.

Benchmarks:
`BenchmarkMarshalJSON-8           	10000000	       126 ns/op	      48 B/op	       1 allocs/op`
`BenchmarkMarshalText-8           	10000000	       189 ns/op	      96 B/op	       2 allocs/op`

`BenchmarkUnmarshalJSON1-8        	10000000	       200 ns/op	       0 B/op	       0 allocs/op`
`BenchmarkUnmarshalJSON2-8        	10000000	       199 ns/op	       0 B/op	       0 allocs/op`
`BenchmarkUnmarshalText-8         	        10000000	       199 ns/op	       0 B/op	       0 allocs/op`
