### PR TITLE
Improve input validation in UnmarshalText

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -264,7 +264,7 @@ func (u *UUID) UnmarshalText(text []byte) (err error) {
 		}
 
 		if i == 4 && len(t) > byteGroup &&
-			((braced && t[byteGroup] != '}') || !braced) {
+			((braced && t[byteGroup] != '}') || len(t[byteGroup:]) > 1 || !braced) {
 			err = fmt.Errorf("uuid: UUID string too long: %s", t)
 			return
 		}

--- a/uuid.go
+++ b/uuid.go
@@ -232,22 +232,40 @@ func (u *UUID) UnmarshalText(text []byte) (err error) {
 	}
 
 	t := text[:]
+	braced := false
 
 	if bytes.Equal(t[:9], urnPrefix) {
 		t = t[9:]
 	} else if t[0] == '{' {
+		braced = true
 		t = t[1:]
 	}
 
 	b := u[:]
 
-	for _, byteGroup := range byteGroups {
-		if t[0] == '-' {
+	for i, byteGroup := range byteGroups {
+		if i > 0 && t[0] == '-' {
 			t = t[1:]
+		} else if i > 0 && t[0] != '-' {
+			err = fmt.Errorf("uuid: invalid string format")
+			return
+		}
+
+		if i == 2 {
+			if !bytes.Contains([]byte("012345"), []byte{t[0]}) {
+				err = fmt.Errorf("uuid: invalid version number: %s", t[0])
+				return
+			}
 		}
 
 		if len(t) < byteGroup {
 			err = fmt.Errorf("uuid: UUID string too short: %s", text)
+			return
+		}
+
+		if i == 4 && len(t) > byteGroup &&
+			((braced && t[byteGroup] != '}') || !braced) {
+			err = fmt.Errorf("uuid: UUID string too long: %s", t)
 			return
 		}
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -241,6 +241,7 @@ func TestFromStringLong(t *testing.T) {
 	s := []string{
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c8=",
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"{6ba7b810-9dad-11d1-80b4-00c04fd430c8}f",
 		"6ba7b810-9dad-11d1-80b4-00c04fd430c800c04fd430c8",
 	}
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -236,6 +236,47 @@ func TestFromStringShort(t *testing.T) {
 	}
 }
 
+func TestFromStringLong(t *testing.T) {
+	// Invalid 37+ character UUID string
+	s := []string{
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8=",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"6ba7b810-9dad-11d1-80b4-00c04fd430c800c04fd430c8",
+	}
+
+	for _, str := range s {
+		_, err := FromString(str)
+		if err == nil {
+			t.Errorf("Should return error trying to parse too long string, passed %s", str)
+		}
+	}
+}
+
+func TestFromStringInvalid(t *testing.T) {
+	// Invalid UUID string formats
+	s := []string{
+		"6ba7b8109dad11d180b400c04fd430c8",
+		"6ba7b8109dad11d180b400c04fd430c86ba7b8109dad11d180b400c04fd430c8",
+		"urn:uuid:{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"6ba7b8109-dad-11d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad1-1d1-80b4-00c04fd430c8",
+		"6ba7b810-9dad-11d18-0b4-00c04fd430c8",
+		"6ba7b810-9dad-11d1-80b40-0c04fd430c8",
+		"6ba7b810+9dad+11d1+80b4+00c04fd430c8",
+		"6ba7b810-9dad11d180b400c04fd430c8",
+		"6ba7b8109dad-11d180b400c04fd430c8",
+		"6ba7b8109dad11d1-80b400c04fd430c8",
+		"6ba7b8109dad11d180b4-00c04fd430c8",
+	}
+
+	for _, str := range s {
+		_, err := FromString(str)
+		if err == nil {
+			t.Errorf("Should return error trying to parse invalid string, passed %s", str)
+		}
+	}
+}
+
 func TestFromStringOrNil(t *testing.T) {
 	u := FromStringOrNil("")
 	if u != Nil {


### PR DESCRIPTION
UnmarshalText accepted a number of invalid strings, most significantly it took the first 32 characters from arbitrarily long hex strings and converted them to a UUID.

This is a breaking change for users that relied on this behaviour to cast UUIDs, ie. hopefully noone.