### PR TITLE
Postgres Scan UUID

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -293,6 +293,9 @@ func (u *UUID) Scan(src interface{}) error {
 
 	case string:
 		return u.UnmarshalText([]byte(src))
+
+	case UUID:
+		return u.UnmarshalBinary(src.Bytes())
 	}
 
 	return fmt.Errorf("uuid: cannot convert %T to UUID", src)


### PR DESCRIPTION
This fixes a case when using the [gorm "ORM" ](https://github.com/jinzhu/gorm) with go.uuid on a Postgres database. When a model defines a field as uuid.UUID the introspection that happens will pass in a `UUID` type. 
