### PR TITLE
Fix errors reported by go vet

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -113,9 +113,11 @@ func BenchmarkUnmarshalText(b *testing.B) {
 	}
 }
 
+var sink string
+
 func BenchmarkMarshalToString(b *testing.B) {
 	u := NewV4()
 	for i := 0; i < b.N; i++ {
-		u.String()
+		sink = u.String()
 	}
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -491,7 +491,7 @@ func TestNullUUIDScanNil(t *testing.T) {
 	}
 
 	if !Equal(u.UUID, Nil) {
-		t.Errorf("NullUUID value should be equal to Nil: %s", u)
+		t.Errorf("NullUUID value should be equal to Nil: %v", u)
 	}
 }
 


### PR DESCRIPTION
For the benchmark, `u.String()` or the loop could
potentially be optimized away by the compiler (see
http://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go for more
information). A format string in uuid_test.go has the wrong type.