### PR TITLE
Add Go 1.7 and latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ go:
     - 1.4
     - 1.5
     - 1.6
+    - 1.7
+    - tip
 before_install:
     - go get github.com/mattn/goveralls
     - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
Go 1.7 was released recently and it seems useful to test against the Go tip as
well, for people that run release candidates.