### PR TITLE
Replace SHA1 to SHA512 to generate V5

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -28,7 +28,7 @@ import (
 	"bytes"
 	"crypto/md5"
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha512"
 	"database/sql/driver"
 	"encoding/binary"
 	"encoding/hex"
@@ -461,9 +461,9 @@ func NewV4() UUID {
 	return u
 }
 
-// NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
+// NewV5 returns UUID based on SHA-512 hash of namespace UUID and name.
 func NewV5(ns UUID, name string) UUID {
-	u := newFromHash(sha1.New(), ns, name)
+	u := newFromHash(sha512.New(), ns, name)
 	u.SetVersion(5)
 	u.SetVariant()
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -611,7 +611,7 @@ func TestNewV5(t *testing.T) {
 
 	u = NewV5(NamespaceDNS, "python.org")
 
-	if u.String() != "886313e1-3b8a-5372-9b90-0c9aee199e5d" {
+	if u.String() != "4b04db65-b6a1-5f48-9654-353e4ded6830" {
 		t.Errorf("UUIDv5 generated incorrectly: %s", u.String())
 	}
 


### PR DESCRIPTION
This change is to generate the uuid V5 with more security. The SHA1 algorithm not being used anymore.