### PR TITLE
Implement json unmarshaller

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -282,6 +282,11 @@ func (u *UUID) UnmarshalText(text []byte) (err error) {
 	return
 }
 
+// UnmarshalJSON implements the encoding.JSONUnmarshaler interface.
+func (u *UUID) UnmarshalJSON(text []byte) (err error) {
+	return u.UnmarshalText(text)
+}
+
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
 func (u UUID) MarshalBinary() (data []byte, err error) {
 	data = u.Bytes()

--- a/uuid.go
+++ b/uuid.go
@@ -284,7 +284,9 @@ func (u *UUID) UnmarshalText(text []byte) (err error) {
 
 // UnmarshalJSON implements the encoding.JSONUnmarshaler interface.
 func (u *UUID) UnmarshalJSON(text []byte) (err error) {
-	return u.UnmarshalText(text)
+	b := bytes.Trim(text, `"\`)
+	err = u.UnmarshalText(b)
+	return
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -332,7 +332,7 @@ func TestUnmarshalText(t *testing.T) {
 
 func TestUnmarshalJSON(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
-	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	b1 := []byte(`\"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"`)
 
 	u1 := UUID{}
 	err := u1.UnmarshalJSON(b1)

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -330,6 +330,29 @@ func TestUnmarshalText(t *testing.T) {
 	}
 }
 
+func TestUnmarshalJSON(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	b1 := []byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+	u1 := UUID{}
+	err := u1.UnmarshalJSON(b1)
+	if err != nil {
+		t.Errorf("Error unmarshaling UUID: %s", err)
+	}
+
+	if !Equal(u, u1) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u1)
+	}
+
+	b2 := []byte("")
+	u2 := UUID{}
+
+	err = u2.UnmarshalJSON(b2)
+	if err == nil {
+		t.Errorf("Should return error trying to unmarshal from empty string")
+	}
+}
+
 func TestValue(t *testing.T) {
 	u, err := FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	if err != nil {


### PR DESCRIPTION
Implementing the Unmarshaller for the JSON encoder would be nice. Any thoughts? Here is a rough addition.

It also might be nice to add an Error Type of `uuid.SyntaxError` or `uuid.ParseError` in the future (like https://golang.org/pkg/encoding/json/#SyntaxError or https://golang.org/pkg/time/#ParseError )