### PR TITLE
Add convenience function for checking for a Nil UUID

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -323,6 +323,11 @@ func (u *UUID) Scan(src interface{}) error {
 	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
 }
 
+// Returns true if the current UUID equals Nil; otherwise returns false.
+func (u *UUID) IsNil() bool {
+	return Equal(*u, Nil)
+}
+
 // Value implements the driver.Valuer interface.
 func (u NullUUID) Value() (driver.Value, error) {
 	if !u.Valid {

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -459,6 +459,17 @@ func TestScanNil(t *testing.T) {
 	}
 }
 
+func TestIsNil(t *testing.T) {
+	u := Nil
+	if !u.IsNil() {
+		t.Errorf("Error UUID should be detected as nil: %s", u.String())
+	}
+	u = NewV1()
+	if u.IsNil() {
+		t.Errorf("Error UUID should not be detected as nil: %s", u.String())
+	}
+}
+
 func TestNullUUIDScanValid(t *testing.T) {
 	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
 	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"


### PR DESCRIPTION
I've added the convenience method `UUID.IsNil() bool` for easy checking if a UUID is Nil.