### PR TITLE
Add must helper

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -479,3 +479,14 @@ func newFromHash(h hash.Hash, ns UUID, name string) UUID {
 
 	return u
 }
+
+// Must is a helper that wraps a call to a function returning (UUID, error)
+// and panics if the error is non-nil. It is intended for use in variable
+// initializations such as
+//	var packageUUID = uuid.Must(uuid.FromString("123e4567-e89b-12d3-a456-426655440000"));
+func Must(u UUID, err error) UUID {
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
A Must function is idiomatic go; the benefit of having a must is to
panic when it is not a valid UUID vs error handle.

This branch is a WIP because I wanted to discuss the proper contributions of test cases as well for this repo. This closes #42 