### PR TITLE
Refactor UnmarshalText in order to parse hash-like UUID.

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -229,57 +229,136 @@ func (u UUID) MarshalText() (text []byte, err error) {
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // Following formats are supported:
-// "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
-// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
-// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//   "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+//   "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+//   "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+//   "6ba7b8109dad11d180b400c04fd430c8"
+// ABNF for supported UUID text representation follows:
+//   uuid := canonical | hashlike | braced | urn
+//   plain := canonical | hashlike
+//   canonical := 4hexoct '-' 2hexoct '-' 2hexoct '-' 6hexoct
+//   hashlike := 12hexoct
+//   braced := '{' plain '}'
+//   urn := URN ':' UUID-NIS ':' plain
+//   URN := 'urn'
+//   UUID-NID := 'uuid'
+//   12hexoct := 6hexoct 6hexoct
+//   6hexoct := 4hexoct 2hexoct
+//   4hexoct := 2hexoct 2hexoct
+//   2hexoct := hexoct hexoct
+//   hexoct := hexdig hexdig
+//   hexdig := '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' |
+//             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
+//             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
 func (u *UUID) UnmarshalText(text []byte) (err error) {
 	if len(text) < 32 {
 		err = fmt.Errorf("uuid: UUID string too short: %s", text)
 		return
 	}
 
-	t := text[:]
-	braced := false
+	if err := u.decodeCanonical(text); err == nil {
+		return nil
+	} else if err := u.decodeHashLike(text); err == nil {
+		return nil
+	} else if err := u.decodeBraced(text); err == nil {
+		return nil
+	} else if err := u.decodeURN(text); err == nil {
+		return nil
+	} else {
+		return fmt.Errorf("uuid: wrong uuid format")
+	}
+}
 
-	if bytes.Equal(t[:9], urnPrefix) {
-		t = t[9:]
-	} else if t[0] == '{' {
-		braced = true
-		t = t[1:]
+// decodeCanonical decodes UUID string in format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
+func (u *UUID) decodeCanonical(t []byte) (err error) {
+	if len(t) != 36 {
+		return fmt.Errorf("uuid: it is not canonical format")
 	}
 
-	b := u[:]
-
-	for i, byteGroup := range byteGroups {
-		if i > 0 {
-			if t[0] != '-' {
-				err = fmt.Errorf("uuid: invalid string format")
-				return
-			}
-			t = t[1:]
-		}
-
-		if len(t) < byteGroup {
-			err = fmt.Errorf("uuid: UUID string too short: %s", text)
-			return
-		}
-
-		if i == 4 && len(t) > byteGroup &&
-			((braced && t[byteGroup] != '}') || len(t[byteGroup:]) > 1 || !braced) {
-			err = fmt.Errorf("uuid: UUID string too long: %s", text)
-			return
-		}
-
-		_, err = hex.Decode(b[:byteGroup/2], t[:byteGroup])
-		if err != nil {
-			return
-		}
-
-		t = t[byteGroup:]
-		b = b[byteGroup/2:]
+	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
+		return fmt.Errorf("uuid: it is not canonical format")
 	}
 
-	return
+	src := t[:8]
+	src = append(src, t[9:13]...)
+	src = append(src, t[14:18]...)
+	src = append(src, t[19:23]...)
+	src = append(src, t[24:36]...)
+
+	dst := u[:]
+
+	if _, err = hex.Decode(dst, src); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+// decodeCanonical decodes UUID string in format
+// "6ba7b8109dad11d180b400c04fd430c8"
+func (u *UUID) decodeHashLike(t []byte) (err error) {
+	if len(t) != 32 {
+		return fmt.Errorf("uuid: wrong size of input string")
+	}
+
+	src := t[:]
+	dst := u[:]
+
+	if _, err = hex.Decode(dst, src); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+// decodeCanonical decodes UUID string in format
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}".
+func (u *UUID) decodeBraced(t []byte) (err error) {
+	l := len(t)
+
+	if l != 34 && l != 38 {
+		return fmt.Errorf("uuid: wrong size of input string")
+	}
+
+	if t[0] != '{' || t[l-1] != '}' {
+		return fmt.Errorf("uuid: it is not braced format")
+	}
+
+	return u.decodePlain(t[1 : l-1])
+}
+
+// decodeCanonical decodes UUID string in format
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+func (u *UUID) decodeURN(t []byte) (err error) {
+	total := len(t)
+	nss := total - 9 // length of nss
+
+	if nss != 32 && nss != 36 {
+		return fmt.Errorf("uuid: wrong size of input string")
+	}
+
+	// TODO: should be 'urn:uuid:' case-insensitive
+	urn_uuid_prefix := t[:9]
+
+	if !bytes.Equal(urn_uuid_prefix, urnPrefix) {
+		return fmt.Errorf("uuid: it is not URN format")
+	}
+
+	return u.decodePlain(t[9:total])
+}
+
+// decodeCanonical decodes UUID string in canonical format
+// "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
+// "6ba7b8109dad11d180b400c04fd430c8".
+func (u *UUID) decodePlain(t []byte) (err error) {
+	if err := u.decodeCanonical(t); err == nil {
+		return nil
+	} else if err := u.decodeHashLike(t); err != nil {
+		return nil
+	} else {
+		return fmt.Errorf("uuid: it is not braced format")
+	}
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.

--- a/uuid.go
+++ b/uuid.go
@@ -276,10 +276,6 @@ func (u *UUID) UnmarshalText(text []byte) (err error) {
 // decodeCanonical decodes UUID string in format
 // "6ba7b810-9dad-11d1-80b4-00c04fd430c8".
 func (u *UUID) decodeCanonical(t []byte) (err error) {
-	if len(t) != 36 {
-		return fmt.Errorf("uuid: it is not canonical format")
-	}
-
 	if t[8] != '-' || t[13] != '-' || t[18] != '-' || t[23] != '-' {
 		return fmt.Errorf("uuid: it is not canonical format")
 	}
@@ -302,10 +298,6 @@ func (u *UUID) decodeCanonical(t []byte) (err error) {
 // decodeCanonical decodes UUID string in format
 // "6ba7b8109dad11d180b400c04fd430c8"
 func (u *UUID) decodeHashLike(t []byte) (err error) {
-	if len(t) != 32 {
-		return fmt.Errorf("uuid: wrong size of input string")
-	}
-
 	src := t[:]
 	dst := u[:]
 
@@ -321,10 +313,6 @@ func (u *UUID) decodeHashLike(t []byte) (err error) {
 func (u *UUID) decodeBraced(t []byte) (err error) {
 	l := len(t)
 
-	if l != 34 && l != 38 {
-		return fmt.Errorf("uuid: wrong size of input string")
-	}
-
 	if t[0] != '{' || t[l-1] != '}' {
 		return fmt.Errorf("uuid: it is not braced format")
 	}
@@ -336,11 +324,6 @@ func (u *UUID) decodeBraced(t []byte) (err error) {
 // "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 func (u *UUID) decodeURN(t []byte) (err error) {
 	total := len(t)
-	nss := total - 9 // length of nss
-
-	if nss != 32 && nss != 36 {
-		return fmt.Errorf("uuid: wrong size of input string")
-	}
 
 	// TODO: should be 'urn:uuid:' case-insensitive
 	urn_uuid_prefix := t[:9]
@@ -356,13 +339,16 @@ func (u *UUID) decodeURN(t []byte) (err error) {
 // "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
 // "6ba7b8109dad11d180b400c04fd430c8".
 func (u *UUID) decodePlain(t []byte) (err error) {
-	if err := u.decodeCanonical(t); err == nil {
-		return nil
-	} else if err := u.decodeHashLike(t); err != nil {
-		return nil
-	} else {
-		return fmt.Errorf("uuid: it is not braced format")
+	switch len(t) {
+	case 32:
+		err = u.decodeHashLike(t)
+	case 36:
+		err = u.decodeCanonical(t)
+	default:
+		err = fmt.Errorf("uuid: wrong length for plain format")
 	}
+
+	return
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.

--- a/uuid.go
+++ b/uuid.go
@@ -295,8 +295,8 @@ func (u *UUID) decodeCanonical(t []byte) (err error) {
 	}
 }
 
-// decodeCanonical decodes UUID string in format
-// "6ba7b8109dad11d180b400c04fd430c8"
+// decodeHashLike decodes UUID string in format
+// "6ba7b8109dad11d180b400c04fd430c8".
 func (u *UUID) decodeHashLike(t []byte) (err error) {
 	src := t[:]
 	dst := u[:]
@@ -308,8 +308,9 @@ func (u *UUID) decodeHashLike(t []byte) (err error) {
 	}
 }
 
-// decodeCanonical decodes UUID string in format
-// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}".
+// decodeBraced decodes UUID string in format
+// "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}" or in format
+// "{6ba7b8109dad11d180b400c04fd430c8}".
 func (u *UUID) decodeBraced(t []byte) (err error) {
 	l := len(t)
 
@@ -320,8 +321,9 @@ func (u *UUID) decodeBraced(t []byte) (err error) {
 	return u.decodePlain(t[1 : l-1])
 }
 
-// decodeCanonical decodes UUID string in format
-// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+// decodeURN decodes UUID string in format
+// "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in format
+// "urn:uuid:6ba7b8109dad11d180b400c04fd430c8".
 func (u *UUID) decodeURN(t []byte) (err error) {
 	total := len(t)
 
@@ -335,7 +337,7 @@ func (u *UUID) decodeURN(t []byte) (err error) {
 	return u.decodePlain(t[9:total])
 }
 
-// decodeCanonical decodes UUID string in canonical format
+// decodePlain decodes UUID string in canonical format
 // "6ba7b810-9dad-11d1-80b4-00c04fd430c8" or in hash-like format
 // "6ba7b8109dad11d180b400c04fd430c8".
 func (u *UUID) decodePlain(t []byte) (err error) {

--- a/uuid.go
+++ b/uuid.go
@@ -251,21 +251,25 @@ func (u UUID) MarshalText() (text []byte, err error) {
 //             'a' | 'b' | 'c' | 'd' | 'e' | 'f' |
 //             'A' | 'B' | 'C' | 'D' | 'E' | 'F'
 func (u *UUID) UnmarshalText(text []byte) (err error) {
-	if len(text) < 32 {
-		err = fmt.Errorf("uuid: UUID string too short: %s", text)
-		return
+	switch len(text) {
+	case 32:
+		return u.decodeHashLike(text)
+	case 36:
+		return u.decodeCanonical(text)
+	case 38:
+		return u.decodeBraced(text)
+	case 41:
+		fallthrough
+	case 45:
+		return u.decodeURN(text)
 	}
 
-	if err := u.decodeCanonical(text); err == nil {
-		return nil
-	} else if err := u.decodeHashLike(text); err == nil {
-		return nil
-	} else if err := u.decodeBraced(text); err == nil {
-		return nil
-	} else if err := u.decodeURN(text); err == nil {
-		return nil
+	if len(text) < 32 {
+		return fmt.Errorf("uuid: UUID string too short: %s", text)
+	} else if len(text) > 45 {
+		return fmt.Errorf("uuid: UUID string too long: %s", text)
 	} else {
-		return fmt.Errorf("uuid: wrong uuid format")
+		return fmt.Errorf("uuid: wrong length of UUID string: %s", text)
 	}
 }
 

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -190,6 +190,7 @@ func TestFromString(t *testing.T) {
 	s1 := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	s2 := "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"
 	s3 := "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	s4 := "6ba7b8109dad11d180b400c04fd430c8"
 
 	_, err := FromString("")
 	if err == nil {
@@ -221,6 +222,15 @@ func TestFromString(t *testing.T) {
 
 	if !Equal(u, u3) {
 		t.Errorf("UUIDs should be equal: %s and %s", u, u3)
+	}
+
+	u4, err := FromString(s4)
+	if err != nil {
+		t.Errorf("Error parsing UUID from string: %s", err)
+	}
+
+	if !Equal(u, u4) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u4)
 	}
 }
 
@@ -256,7 +266,6 @@ func TestFromStringLong(t *testing.T) {
 func TestFromStringInvalid(t *testing.T) {
 	// Invalid UUID string formats
 	s := []string{
-		"6ba7b8109dad11d180b400c04fd430c8",
 		"6ba7b8109dad11d180b400c04fd430c86ba7b8109dad11d180b400c04fd430c8",
 		"urn:uuid:{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
 		"6ba7b8109-dad-11d1-80b4-00c04fd430c8",

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -191,6 +191,7 @@ func TestFromString(t *testing.T) {
 	s2 := "{6ba7b810-9dad-11d1-80b4-00c04fd430c8}"
 	s3 := "urn:uuid:6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 	s4 := "6ba7b8109dad11d180b400c04fd430c8"
+	s5 := "urn:uuid:6ba7b8109dad11d180b400c04fd430c8"
 
 	_, err := FromString("")
 	if err == nil {
@@ -232,6 +233,15 @@ func TestFromString(t *testing.T) {
 	if !Equal(u, u4) {
 		t.Errorf("UUIDs should be equal: %s and %s", u, u4)
 	}
+
+	u5, err := FromString(s5)
+	if err != nil {
+		t.Errorf("Error parsing UUID from string: %s", err)
+	}
+
+	if !Equal(u, u5) {
+		t.Errorf("UUIDs should be equal: %s and %s", u, u5)
+	}
 }
 
 func TestFromStringShort(t *testing.T) {
@@ -268,11 +278,16 @@ func TestFromStringInvalid(t *testing.T) {
 	s := []string{
 		"6ba7b8109dad11d180b400c04fd430c86ba7b8109dad11d180b400c04fd430c8",
 		"urn:uuid:{6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"uuid:urn:6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		"uuid:urn:6ba7b8109dad11d180b400c04fd430c8",
 		"6ba7b8109-dad-11d1-80b4-00c04fd430c8",
 		"6ba7b810-9dad1-1d1-80b4-00c04fd430c8",
 		"6ba7b810-9dad-11d18-0b4-00c04fd430c8",
 		"6ba7b810-9dad-11d1-80b40-0c04fd430c8",
 		"6ba7b810+9dad+11d1+80b4+00c04fd430c8",
+		"(6ba7b810-9dad-11d1-80b4-00c04fd430c8}",
+		"{6ba7b810-9dad-11d1-80b4-00c04fd430c8>",
+		"zba7b810-9dad-11d1-80b4-00c04fd430c8",
 		"6ba7b810-9dad11d180b400c04fd430c8",
 		"6ba7b8109dad-11d180b400c04fd430c8",
 		"6ba7b8109dad11d1-80b400c04fd430c8",


### PR DESCRIPTION
I refactor `UnmarshalText` in order to support yet another text representation of UUID lilke `6ba7b8109dad11d180b400c04fd430c8`. The reason is that this format is quite frequent.

I tried to introduce BNF of what `UmarshalText` actually does.  In fact it simplifies implementation and future support. On other hand current implementation led to performance degradation(see below before/after).

**BEFORE**
```
BenchmarkFromString-4               	10000000	       122 ns/op
BenchmarkFromStringUrn-4            	10000000	       124 ns/op
BenchmarkFromStringWithBrackets-4   	10000000	       123 ns/op
BenchmarkUnmarshalText-4            	20000000	        81.6 ns/op
PASS
ok  	github.com/daskol/go.uuid	25.786s
```

**AFTER**
```
BenchmarkFromString-4               	20000000	        91.7 ns/op
BenchmarkFromStringUrn-4            	 3000000	       493 ns/op
BenchmarkFromStringWithBrackets-4   	 5000000	       358 ns/op
BenchmarkUnmarshalText-4            	 2000000	       612 ns/op
PASS
ok  	github.com/daskol/go.uuid	27.822s
```

Eventually correct `UnmarshalText` should be based on FSA to avoid overhead during parsing.