### PR TITLE
Add method to get UUID as string without dashes.

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -213,15 +213,7 @@ func (u UUID) String() string {
 // Returns string representation of UUID without dashes:
 // xxxxxxxx(-)xxxx(-)xxxx(-)xxxx(-)xxxxxxxxxxxx.
 func (u UUID) StringWithoutDashes() string {
-	buf := make([]byte, 32)
-
-	hex.Encode(buf[0:8], u[0:4])
-	hex.Encode(buf[8:12], u[4:6])
-	hex.Encode(buf[12:16], u[6:8])
-	hex.Encode(buf[16:20], u[8:10])
-	hex.Encode(buf[20:], u[10:])
-
-	return string(buf)
+	return hex.EncodeToString(u.Bytes())
 }
 
 // SetVersion sets version bits.

--- a/uuid.go
+++ b/uuid.go
@@ -210,6 +210,20 @@ func (u UUID) String() string {
 	return string(buf)
 }
 
+// Returns string representation of UUID without dashes:
+// xxxxxxxx(-)xxxx(-)xxxx(-)xxxx(-)xxxxxxxxxxxx.
+func (u UUID) StringWithoutDashes() string {
+	buf := make([]byte, 32)
+
+	hex.Encode(buf[0:8], u[0:4])
+	hex.Encode(buf[8:12], u[4:6])
+	hex.Encode(buf[12:16], u[6:8])
+	hex.Encode(buf[16:20], u[8:10])
+	hex.Encode(buf[20:], u[10:])
+
+	return string(buf)
+}
+
 // SetVersion sets version bits.
 func (u *UUID) SetVersion(v byte) {
 	u[6] = (u[6] & 0x0f) | (v << 4)

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -42,6 +42,12 @@ func TestString(t *testing.T) {
 	}
 }
 
+func TestStringWithoutDashes(t *testing.T) {
+	if NamespaceDNS.StringWithoutDashes() != "6ba7b8109dad11d180b400c04fd430c8" {
+		t.Errorf("Incorrect string representation for UUID: %s", NamespaceDNS.StringWithoutDashes())
+	}
+}
+
 func TestEqual(t *testing.T) {
 	if !Equal(NamespaceDNS, NamespaceDNS) {
 		t.Errorf("Incorrect comparison of %s and %s", NamespaceDNS, NamespaceDNS)


### PR DESCRIPTION
I need the possibility to have an UUID string without dashes in my project.
I didn't want to use strings package to manage it since it could be a new simple functionality.