### PR TITLE
Add Generator interface

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -24,10 +24,10 @@
 // version 2 (as specified in DCE 1.1).
 package uuid
 
-// Generator can create any type od UUID.
+// Generator can create any type of UUID.
 type Generator interface {
 	NewV1() UUID
-	NewV2(domaing byte) UUID
+	NewV2(domain byte) UUID
 	NewV3(ns UUID, name string) UUID
 	NewV4() UUID
 	NewV5(ns UUID, name string) UUID

--- a/generator.go
+++ b/generator.go
@@ -1,0 +1,21 @@
+package uuid
+
+type Generator interface {
+	NewV1() UUID
+	NewV2(domaing byte) UUID
+	NewV3(ns UUID, name string) UUID
+	NewV4() UUID
+	NewV5(ns UUID, name string) UUID
+}
+
+type standard struct{}
+
+func (_ standard) NewV1() UUID                     { return NewV1() }
+func (_ standard) NewV2(domain byte) UUID          { return NewV2(domain) }
+func (_ standard) NewV3(ns UUID, name string) UUID { return NewV3(ns, name) }
+func (_ standard) NewV4() UUID                     { return NewV4() }
+func (_ standard) NewV5(ns UUID, name string) UUID { return NewV5(ns, name) }
+
+func NewGenerator() Generator {
+	return standard{}
+}

--- a/generator.go
+++ b/generator.go
@@ -24,6 +24,7 @@
 // version 2 (as specified in DCE 1.1).
 package uuid
 
+// Generator can create any type od UUID.
 type Generator interface {
 	NewV1() UUID
 	NewV2(domaing byte) UUID
@@ -40,6 +41,8 @@ func (_ standard) NewV3(ns UUID, name string) UUID { return NewV3(ns, name) }
 func (_ standard) NewV4() UUID                     { return NewV4() }
 func (_ standard) NewV5(ns UUID, name string) UUID { return NewV5(ns, name) }
 
+// NewGenerator returns a standard UUID generator which will generatr UUIDs in the same manner
+// as the standalone creation functions.
 func NewGenerator() Generator {
 	return standard{}
 }

--- a/generator.go
+++ b/generator.go
@@ -1,3 +1,27 @@
+// Copyright (C) 2013-2015 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
 package uuid
 
 type Generator interface {

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,39 @@
+package uuid
+
+import (
+	"testing"
+)
+
+func TestNewGenerator(t *testing.T) {
+	generator := NewGenerator()
+
+	u1 := generator.NewV1()
+	if u1.Version() != 1 {
+		t.Errorf("UUIDv1 generated with incorrect version: %d", u1.Version())
+	}
+
+	u2 := generator.NewV2(DomainPerson)
+
+	if u2.Version() != 2 {
+		t.Errorf("UUIDv2 generated with incorrect version: %d", u2.Version())
+	}
+
+	u3 := generator.NewV3(NamespaceDNS, "www.example.com")
+
+	if u3.Version() != 3 {
+		t.Errorf("UUIDv3 generated with incorrect version: %d", u3.Version())
+	}
+
+	u4 := generator.NewV4()
+
+	if u4.Version() != 4 {
+		t.Errorf("UUIDv4 generated with incorrect version: %d", u4.Version())
+	}
+
+	u5 := generator.NewV5(NamespaceDNS, "www.example.com")
+
+	if u5.Version() != 5 {
+		t.Errorf("UUIDv3 generated with incorrect version: %d", u5.Version())
+	}
+
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,3 +1,27 @@
+// Copyright (C) 2013-2015 by Maxim Bublis <b@codemonkey.ru>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package uuid provides implementation of Universally Unique Identifier (UUID).
+// Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
+// version 2 (as specified in DCE 1.1).
 package uuid
 
 import (


### PR DESCRIPTION
In certain cases (namely testing) a person may want to deterministically generate UUIDs. There currently aren't many facilities in this UUID library for doing this.

I propose introducing a new interface called `Generator`. A `Generator` has all of the standard uuid creation functions on it, but has the advantage of being able to be mocked. Developers wishing to write more testable code can write code that instead of directly using the creation function, instead uses some instance of the `Generator` interface. For the code they actually want to run, they can inject the `Generator` returned by the `NewGenerator` function. When they want to test, they can inject a mocked `Generator` of their choice (using mockgen, mockery, or their own custom implementation) and deterministically control what UUIDs are generated.

For instance, consider the following generator that might be used for testing. In this case, the author only cares about deterministically generating a certain sequence of V4 UUIDS.
```
type MyTestGen struct {
  Sequence []satori.UUID
  Iter            int
}

func (_ MyTestGen) NewV1() satori.UUID{return  satori.Nil}
func (_ MyTestGen) NewV2(domain byte) satori.UUID{return  satori.Nil}
func (_ MyTestGen) NewV3(ns UUID, name string) satori.UUID{return  satori.Nil}
func (m MyTestGen) NewV4() satori.UUID{
  toReturn := m.Sequence[m.Iter]
  m.Iter += 1
  return toReturn
}
func (_ MyTestGen) NewV5(ns UUID, name string) satori.UUID{return  satori.Nil}