### PR TITLE
Revert breaking changes and add new GenV* interfaces

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -61,7 +61,7 @@ func (s *codecTestSuite) TestMarshalBinary(c *C) {
 }
 
 func (s *codecTestSuite) BenchmarkMarshalBinary(c *C) {
-	u, err := NewV4()
+	u, err := GenV4()
 	c.Assert(err, IsNil)
 	for i := 0; i < c.N; i++ {
 		u.MarshalBinary()
@@ -210,7 +210,7 @@ func (s *codecTestSuite) TestMarshalText(c *C) {
 }
 
 func (s *codecTestSuite) BenchmarkMarshalText(c *C) {
-	u, err := NewV4()
+	u, err := GenV4()
 	c.Assert(err, IsNil)
 	for i := 0; i < c.N; i++ {
 		u.MarshalText()
@@ -243,7 +243,7 @@ func (s *codecTestSuite) BenchmarkUnmarshalText(c *C) {
 var sink string
 
 func (s *codecTestSuite) BenchmarkMarshalToString(c *C) {
-	u, err := NewV4()
+	u, err := GenV4()
 	c.Assert(err, IsNil)
 	for i := 0; i < c.N; i++ {
 		sink = u.String()

--- a/generator.go
+++ b/generator.go
@@ -49,14 +49,32 @@ var (
 	posixGID = uint32(os.Getgid())
 )
 
-// NewV1 returns UUID based on current timestamp and MAC address.
-func NewV1() (UUID, error) {
+// GenV1 returns UUID based on current timestamp and MAC address.
+func GenV1() (UUID, error) {
 	return global.NewV1()
 }
 
-// NewV2 returns DCE Security UUID based on POSIX UID/GID.
-func NewV2(domain byte) (UUID, error) {
+// NewV1 reliably returns UUID based on current timestamp and MAC address.
+func NewV1() UUID {
+	u, err := GenV1()
+	for err != nil {
+		u, err = GenV1()
+	}
+	return u
+}
+
+// GenV2 returns DCE Security UUID based on POSIX UID/GID.
+func GenV2(domain byte) (UUID, error) {
 	return global.NewV2(domain)
+}
+
+// NewV2 reliably returns DCE Security UUID based on POSIX UID/GID.
+func NewV2(domain byte) UUID {
+	u, err := GenV2(domain)
+	for err != nil {
+		u, err = GenV2(domain)
+	}
+	return u
 }
 
 // NewV3 returns UUID based on MD5 hash of namespace UUID and name.
@@ -64,9 +82,18 @@ func NewV3(ns UUID, name string) UUID {
 	return global.NewV3(ns, name)
 }
 
-// NewV4 returns random generated UUID.
-func NewV4() (UUID, error) {
+// GenV4 returns random generated UUID.
+func GenV4() (UUID, error) {
 	return global.NewV4()
+}
+
+// NewV4 reliably returns random generated UUID.
+func NewV4() UUID {
+	u, err := GenV4()
+	for err != nil {
+		u, err = GenV4()
+	}
+	return u
 }
 
 // NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.

--- a/generator_test.go
+++ b/generator_test.go
@@ -47,18 +47,27 @@ type genTestSuite struct{}
 
 var _ = Suite(&genTestSuite{})
 
-func (s *genTestSuite) TestNewV1(c *C) {
-	u1, err := NewV1()
+func (s *genTestSuite) TestGenV1(c *C) {
+	u1, err := GenV1()
 	c.Assert(err, IsNil)
 	c.Assert(u1.Version(), Equals, V1)
 	c.Assert(u1.Variant(), Equals, VariantRFC4122)
 
-	u2, err := NewV1()
+	u2, err := GenV1()
 	c.Assert(err, IsNil)
 	c.Assert(u1, Not(Equals), u2)
 }
 
-func (s *genTestSuite) TestNewV1EpochStale(c *C) {
+func (s *genTestSuite) TestNewV1(c *C) {
+	u1 := NewV1()
+	c.Assert(u1.Version(), Equals, V1)
+	c.Assert(u1.Variant(), Equals, VariantRFC4122)
+
+	u2 := NewV1()
+	c.Assert(u1, Not(Equals), u2)
+}
+
+func (s *genTestSuite) TestGeneratorNewV1EpochStale(c *C) {
 	g := &rfc4122Generator{
 		epochFunc: func() time.Time {
 			return time.Unix(0, 0)
@@ -73,7 +82,7 @@ func (s *genTestSuite) TestNewV1EpochStale(c *C) {
 	c.Assert(u1, Not(Equals), u2)
 }
 
-func (s *genTestSuite) TestNewV1FaultyRand(c *C) {
+func (s *genTestSuite) TestGeneratorNewV1FaultyRand(c *C) {
 	g := &rfc4122Generator{
 		epochFunc:  time.Now,
 		hwAddrFunc: defaultHWAddrFunc,
@@ -84,7 +93,7 @@ func (s *genTestSuite) TestNewV1FaultyRand(c *C) {
 	c.Assert(u1, Equals, Nil)
 }
 
-func (s *genTestSuite) TestNewV1MissingNetworkInterfaces(c *C) {
+func (s *genTestSuite) TestGeneratorNewV1MissingNetworkInterfaces(c *C) {
 	g := &rfc4122Generator{
 		epochFunc: time.Now,
 		hwAddrFunc: func() (net.HardwareAddr, error) {
@@ -96,7 +105,7 @@ func (s *genTestSuite) TestNewV1MissingNetworkInterfaces(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *genTestSuite) TestNewV1MissingNetInterfacesAndFaultyRand(c *C) {
+func (s *genTestSuite) TestGeneratorNewV1MissingNetInterfacesAndFaultyRand(c *C) {
 	g := &rfc4122Generator{
 		epochFunc: time.Now,
 		hwAddrFunc: func() (net.HardwareAddr, error) {
@@ -117,24 +126,38 @@ func (s *genTestSuite) BenchmarkNewV1(c *C) {
 	}
 }
 
-func (s *genTestSuite) TestNewV2(c *C) {
-	u1, err := NewV2(DomainPerson)
+func (s *genTestSuite) TestGenV2(c *C) {
+	u1, err := GenV2(DomainPerson)
 	c.Assert(err, IsNil)
 	c.Assert(u1.Version(), Equals, V2)
 	c.Assert(u1.Variant(), Equals, VariantRFC4122)
 
-	u2, err := NewV2(DomainGroup)
+	u2, err := GenV2(DomainGroup)
 	c.Assert(err, IsNil)
 	c.Assert(u2.Version(), Equals, V2)
 	c.Assert(u2.Variant(), Equals, VariantRFC4122)
 
-	u3, err := NewV2(DomainOrg)
+	u3, err := GenV2(DomainOrg)
 	c.Assert(err, IsNil)
 	c.Assert(u3.Version(), Equals, V2)
 	c.Assert(u3.Variant(), Equals, VariantRFC4122)
 }
 
-func (s *genTestSuite) TestNewV2FaultyRand(c *C) {
+func (s *genTestSuite) TestNewV2(c *C) {
+	u1 := NewV2(DomainPerson)
+	c.Assert(u1.Version(), Equals, V2)
+	c.Assert(u1.Variant(), Equals, VariantRFC4122)
+
+	u2 := NewV2(DomainGroup)
+	c.Assert(u2.Version(), Equals, V2)
+	c.Assert(u2.Variant(), Equals, VariantRFC4122)
+
+	u3 := NewV2(DomainOrg)
+	c.Assert(u3.Version(), Equals, V2)
+	c.Assert(u3.Variant(), Equals, VariantRFC4122)
+}
+
+func (s *genTestSuite) TestGeneratorNewV2FaultyRand(c *C) {
 	g := &rfc4122Generator{
 		epochFunc:  time.Now,
 		hwAddrFunc: defaultHWAddrFunc,
@@ -173,18 +196,27 @@ func (s *genTestSuite) BenchmarkNewV3(c *C) {
 	}
 }
 
-func (s *genTestSuite) TestNewV4(c *C) {
-	u1, err := NewV4()
+func (s *genTestSuite) TestGenV4(c *C) {
+	u1, err := GenV4()
 	c.Assert(err, IsNil)
 	c.Assert(u1.Version(), Equals, V4)
 	c.Assert(u1.Variant(), Equals, VariantRFC4122)
 
-	u2, err := NewV4()
+	u2, err := GenV4()
 	c.Assert(err, IsNil)
 	c.Assert(u1, Not(Equals), u2)
 }
 
-func (s *genTestSuite) TestNewV4FaultyRand(c *C) {
+func (s *genTestSuite) TestNewV4(c *C) {
+	u1 := NewV4()
+	c.Assert(u1.Version(), Equals, V4)
+	c.Assert(u1.Variant(), Equals, VariantRFC4122)
+
+	u2 := NewV4()
+	c.Assert(u1, Not(Equals), u2)
+}
+
+func (s *genTestSuite) TestGeneratorNewV4FaultyRand(c *C) {
 	g := &rfc4122Generator{
 		epochFunc:  time.Now,
 		hwAddrFunc: defaultHWAddrFunc,


### PR DESCRIPTION
Based on the discussion I saw from issues #66 and #67 I've monkey patched the code for what could be a possible reference point for the future interface of the library. TBH it is a messy and minimal patch and there must be more discussion on how these API changes should roll out. In the meantime this patch should provide the interfaces necessary to keep old code alive while promoting the use of the new interface.

Changes made in the commit:
- Rename current global namespace NewV* methods to GenV\*.
- Add novel NewV\* functions all with return signatures of UUID which loops until no error is returned.\*
- Patch tests to comply with the changes above.

\*This is just an idea that was presented in #66 and I personally thought might be good because the issue addressed in #18 seemed to be a non-deterministic behavior (which I could very well be misunderstanding). If errors are persistent across trials  (and after reading the test code I've been getting an impression that they might be so) panicking might be the only option (although I cannot tell whether or not the `global` instance can potentially raise errors caught in the test cases).

Things to discuss:
- Is there a better solution other than having to revert the API changes?
- If this way of implementing is feasible, should the methods defined on the Generator interfaces be renamed? (Maybe to GenV\*? That may sound redundant so maybe just plain V\*?)
- Naming conventions in general.
- How should errors that occurred during reliable UUID generation be handled? (or can it be handled at all?)