### PR TITLE
Add missing return to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ func main() {
 	u2, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 	if err != nil {
 		fmt.Printf("Something went wrong: %s", err)
+		return
 	}
 	fmt.Printf("Successfully parsed: %s", u2)
 }


### PR DESCRIPTION
README is missing a return in the parsing error handler