### PR TITLE
Add deprecation notice to README and package docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 [![Coverage Status](https://coveralls.io/repos/github/satori/go.uuid/badge.svg?branch=master)](https://coveralls.io/github/satori/go.uuid)
 [![GoDoc](http://godoc.org/github.com/satori/go.uuid?status.svg)](http://godoc.org/github.com/satori/go.uuid)
 
+## Deprecation Notice
+
+This repository is now deprecated in favor of the fork maintained by the Go Community, [github.com/gofrs/uuid](https://github.com/gofrs/uuid).
+Please use this new package, while being sure to choose a version newer than v2.0.0. The v2.0.0 release is API-compatible
+with the master branch of this repository.
+
+---
+
 This package provides pure Go implementation of Universally Unique Identifier (UUID). Supported both creation and parsing of UUIDs.
 
 With 100% test coverage and benchmarks out of box.

--- a/uuid.go
+++ b/uuid.go
@@ -22,6 +22,8 @@
 // Package uuid provides implementation of Universally Unique Identifier (UUID).
 // Supported versions are 1, 3, 4 and 5 (as specified in RFC 4122) and
 // version 2 (as specified in DCE 1.1).
+//
+// Deprecated: this package is deprecated in favor of github.com/gofrs/uuid.
 package uuid
 
 import (


### PR DESCRIPTION
This change adds a deprecation notice to the README and package docs to point
users to the fork now maintained by The Gofrs ([github.com/gofrs/uuid](https://github.com/gofrs/uuid)).
It also suggests that they make use of v2.0.0 or newer.

Fixes #84

Signed-off-by: Tim Heckman <t@heckman.io>