### PR TITLE
fix example in README so it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,11 @@ import (
 func main() {
 	// Creating UUID Version 4
 	// panic on error
-	u1 := uuid.Must(uuid.NewV4())
+	u1 := uuid.NewV4()
 	fmt.Printf("UUIDv4: %s\n", u1)
 
 	// or error handling
-	u2, err := uuid.NewV4()
-	if err != nil {
-		fmt.Printf("Something went wrong: %s", err)
-		return
-	}
+	u2 := uuid.NewV4()
 	fmt.Printf("UUIDv4: %s\n", u2)
 
 	// Parsing UUID from string input

--- a/README.md
+++ b/README.md
@@ -37,13 +37,8 @@ import (
 
 func main() {
 	// Creating UUID Version 4
-	// panic on error
 	u1 := uuid.NewV4()
 	fmt.Printf("UUIDv4: %s\n", u1)
-
-	// or error handling
-	u2 := uuid.NewV4()
-	fmt.Printf("UUIDv4: %s\n", u2)
 
 	// Parsing UUID from string input
 	u2, err := uuid.FromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8")


### PR DESCRIPTION
`uuid.NewV4()` only returns a UUID, not a UUID + error which `Must` expects