### PR TITLE
Add Comb UUID

### DIFF
--- a/comb_uuid.go
+++ b/comb_uuid.go
@@ -1,0 +1,44 @@
+package uuid
+
+import (
+	"bytes"
+	"encoding/binary"
+	"time"
+)
+
+type CombUUID UUID
+
+// Equal returns true if this uuid and other uuid equals, otherwise false
+func (u CombUUID) Equal(other CombUUID) bool {
+	return bytes.Equal(u[:], other[:])
+}
+
+// Bytes returns bytes slice representation of UUID.
+func (u CombUUID) Bytes() []byte {
+	return u[:]
+}
+
+// Version returns algorithm version used to generate UUID.
+func (u CombUUID) Version() byte {
+	return u[0] >> 4
+}
+
+// Returns canonical string representation of UUID:
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
+func (u CombUUID) String() string {
+	return UUID(u).String()
+}
+
+// SetVersion sets version bits.
+func (u *CombUUID) SetVersion(v byte) {
+	u[0] = (u[0] & 0x0f) | (v << 4)
+}
+
+// Returns created time in this CombUUID
+func (u *CombUUID) Time() time.Time {
+	t := int64(binary.BigEndian.Uint32(u[4:8]))
+	t |= int64(binary.BigEndian.Uint16(u[2:4])) << 32
+	t |= int64(binary.BigEndian.Uint16(u[0:4])&0xfff) << 48
+
+	return time.Unix(0, (t-epochStart)*100)
+}

--- a/comb_uuid_test.go
+++ b/comb_uuid_test.go
@@ -1,0 +1,73 @@
+package uuid
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func TestCombUUID(t *testing.T) { TestingT(t) }
+
+type testSuiteComb struct{}
+
+var _ = Suite(&testSuiteComb{})
+
+func (s *testSuiteComb) TestBytes(c *C) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	bytes1 := []byte{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+
+	c.Assert(bytes.Equal(u.Bytes(), bytes1), Equals, true)
+}
+
+func (s *testSuiteComb) TestString(c *C) {
+	c.Assert(NamespaceDNS.String(), Equals, "6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+}
+
+func (s *testSuiteComb) TestEqual(c *C) {
+	c.Assert(CombUUID(NamespaceDNS).Equal(CombUUID(NamespaceDNS)), Equals, true)
+	c.Assert(CombUUID(NamespaceDNS).Equal(CombUUID(NamespaceURL)), Equals, false)
+}
+
+func (s *testSuiteComb) TestVersion(c *C) {
+	u := UUID{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	c.Assert(u.Version(), Equals, V1)
+}
+
+func (s *testSuiteComb) TestSetVersion(c *C) {
+	u := UUID{}
+	u.SetVersion(4)
+	c.Assert(u.Version(), Equals, V4)
+}
+
+func (s *testSuiteComb) TestTime(c *C) {
+	now := time.Unix(0, 0)
+
+	g := &rfc4122AndCombGenerator{
+		epochFunc: func() time.Time {
+			return now
+		},
+		hwAddrFunc: defaultHWAddrFunc,
+		rand:       rand.Reader,
+	}
+
+	u1, err := g.NewCombV4()
+	c.Assert(err, IsNil)
+
+	if err == nil {
+		ut := u1.Time()
+		c.Assert(ut.Unix(), Equals, now.Unix())
+	}
+
+	u2, err := g.NewCombV1()
+	c.Assert(err, IsNil)
+
+	if err == nil {
+		ut := u2.Time()
+		c.Assert(ut.Unix(), Equals, now.Unix())
+	}
+}

--- a/generator.go
+++ b/generator.go
@@ -43,7 +43,7 @@ type epochFunc func() time.Time
 type hwAddrFunc func() (net.HardwareAddr, error)
 
 var (
-	global = newRFC4122Generator()
+	global = newRfc4122AndCombGenerator()
 
 	posixUID = uint32(os.Getuid())
 	posixGID = uint32(os.Getgid())
@@ -69,6 +69,16 @@ func NewV4() (UUID, error) {
 	return global.NewV4()
 }
 
+// NewCombV1 returns UUID based on current timestamp and MAC address with ordered-time.
+func NewCombV1() (UUID, error) {
+	return global.NewCombV1()
+}
+
+// NewCombV4 returns UUID based on current timestamp and random generated UUID with ordered-time.
+func NewCombV4() (UUID, error) {
+	return global.NewCombV4()
+}
+
 // NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
 func NewV5(ns UUID, name string) UUID {
 	return global.NewV5(ns, name)
@@ -76,15 +86,20 @@ func NewV5(ns UUID, name string) UUID {
 
 // Generator provides interface for generating UUIDs.
 type Generator interface {
+	// RFC 4122
 	NewV1() (UUID, error)
 	NewV2(domain byte) (UUID, error)
 	NewV3(ns UUID, name string) UUID
 	NewV4() (UUID, error)
 	NewV5(ns UUID, name string) UUID
+
+	// COMB
+	NewCombV1() (UUID, error)
+	NewCombV4() (UUID, error)
 }
 
 // Default generator implementation.
-type rfc4122Generator struct {
+type rfc4122AndCombGenerator struct {
 	clockSequenceOnce sync.Once
 	hardwareAddrOnce  sync.Once
 	storageMutex      sync.Mutex
@@ -98,8 +113,8 @@ type rfc4122Generator struct {
 	hardwareAddr  [6]byte
 }
 
-func newRFC4122Generator() Generator {
-	return &rfc4122Generator{
+func newRfc4122AndCombGenerator() Generator {
+	return &rfc4122AndCombGenerator{
 		epochFunc:  time.Now,
 		hwAddrFunc: defaultHWAddrFunc,
 		rand:       rand.Reader,
@@ -107,7 +122,7 @@ func newRFC4122Generator() Generator {
 }
 
 // NewV1 returns UUID based on current timestamp and MAC address.
-func (g *rfc4122Generator) NewV1() (UUID, error) {
+func (g *rfc4122AndCombGenerator) NewV1() (UUID, error) {
 	u := UUID{}
 
 	timeNow, clockSeq, err := g.getClockSequence()
@@ -132,7 +147,7 @@ func (g *rfc4122Generator) NewV1() (UUID, error) {
 }
 
 // NewV2 returns DCE Security UUID based on POSIX UID/GID.
-func (g *rfc4122Generator) NewV2(domain byte) (UUID, error) {
+func (g *rfc4122AndCombGenerator) NewV2(domain byte) (UUID, error) {
 	u, err := g.NewV1()
 	if err != nil {
 		return Nil, err
@@ -154,7 +169,7 @@ func (g *rfc4122Generator) NewV2(domain byte) (UUID, error) {
 }
 
 // NewV3 returns UUID based on MD5 hash of namespace UUID and name.
-func (g *rfc4122Generator) NewV3(ns UUID, name string) UUID {
+func (g *rfc4122AndCombGenerator) NewV3(ns UUID, name string) UUID {
 	u := newFromHash(md5.New(), ns, name)
 	u.SetVersion(V3)
 	u.SetVariant(VariantRFC4122)
@@ -163,7 +178,7 @@ func (g *rfc4122Generator) NewV3(ns UUID, name string) UUID {
 }
 
 // NewV4 returns random generated UUID.
-func (g *rfc4122Generator) NewV4() (UUID, error) {
+func (g *rfc4122AndCombGenerator) NewV4() (UUID, error) {
 	u := UUID{}
 	if _, err := io.ReadFull(g.rand, u[:]); err != nil {
 		return Nil, err
@@ -175,7 +190,7 @@ func (g *rfc4122Generator) NewV4() (UUID, error) {
 }
 
 // NewV5 returns UUID based on SHA-1 hash of namespace UUID and name.
-func (g *rfc4122Generator) NewV5(ns UUID, name string) UUID {
+func (g *rfc4122AndCombGenerator) NewV5(ns UUID, name string) UUID {
 	u := newFromHash(sha1.New(), ns, name)
 	u.SetVersion(V5)
 	u.SetVariant(VariantRFC4122)
@@ -183,8 +198,55 @@ func (g *rfc4122Generator) NewV5(ns UUID, name string) UUID {
 	return u
 }
 
+// NewCombV1 returns nonstandard UUID based on V1 RFC4122 with timestamp bytes in the front
+func (g *rfc4122AndCombGenerator) NewCombV1() (UUID, error) {
+	u := UUID{}
+
+	timeNow, clockSeq, err := g.getClockSequence()
+	if err != nil {
+		return Nil, err
+	}
+
+	binary.BigEndian.PutUint16(u[0:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[2:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint32(u[4:], uint32(timeNow))
+	binary.BigEndian.PutUint16(u[8:], clockSeq)
+
+	hardwareAddr, err := g.getHardwareAddr()
+	if err != nil {
+		return Nil, err
+	}
+	copy(u[10:], hardwareAddr)
+
+	u.SetVersion(V1)
+	u.SetVariant(VariantFuture)
+
+	return u, nil
+}
+
+// NewCombV4 returns nonstandard UUID based on V4 RFC4122
+// with timestamp bytes in the front (not fully random)
+func (g *rfc4122AndCombGenerator) NewCombV4() (UUID, error) {
+	u := UUID{}
+
+	timeNow := g.getEpoch()
+
+	binary.BigEndian.PutUint16(u[0:], uint16(timeNow>>48))
+	binary.BigEndian.PutUint16(u[2:], uint16(timeNow>>32))
+	binary.BigEndian.PutUint32(u[4:], uint32(timeNow))
+
+	if _, err := io.ReadFull(g.rand, u[8:]); err != nil {
+		return Nil, err
+	}
+
+	u.SetVersion(V4)
+	u.SetVariant(VariantFuture)
+
+	return u, nil
+}
+
 // Returns epoch and clock sequence.
-func (g *rfc4122Generator) getClockSequence() (uint64, uint16, error) {
+func (g *rfc4122AndCombGenerator) getClockSequence() (uint64, uint16, error) {
 	var err error
 	g.clockSequenceOnce.Do(func() {
 		buf := make([]byte, 2)
@@ -212,7 +274,7 @@ func (g *rfc4122Generator) getClockSequence() (uint64, uint16, error) {
 }
 
 // Returns hardware address.
-func (g *rfc4122Generator) getHardwareAddr() ([]byte, error) {
+func (g *rfc4122AndCombGenerator) getHardwareAddr() ([]byte, error) {
 	var err error
 	g.hardwareAddrOnce.Do(func() {
 		if hwAddr, err := g.hwAddrFunc(); err == nil {
@@ -236,7 +298,7 @@ func (g *rfc4122Generator) getHardwareAddr() ([]byte, error) {
 
 // Returns difference in 100-nanosecond intervals between
 // UUID epoch (October 15, 1582) and current time.
-func (g *rfc4122Generator) getEpoch() uint64 {
+func (g *rfc4122AndCombGenerator) getEpoch() uint64 {
 	return epochStart + uint64(g.epochFunc().UnixNano()/100)
 }
 

--- a/generator.go
+++ b/generator.go
@@ -69,12 +69,13 @@ func NewV4() (UUID, error) {
 	return global.NewV4()
 }
 
-// NewCombV1 returns UUID based on current timestamp and MAC address with ordered-time.
+// NewCombV1 returns ordered UUID based on current timestamp and MAC address.
 func NewCombV1() (UUID, error) {
 	return global.NewCombV1()
 }
 
-// NewCombV4 returns UUID based on current timestamp and random generated UUID with ordered-time.
+// NewCombV4 returns UUID based on current timestamp and random generated UUID
+// with ordered created time in 100ns precision.
 func NewCombV4() (UUID, error) {
 	return global.NewCombV4()
 }

--- a/generator.go
+++ b/generator.go
@@ -230,7 +230,7 @@ func (g *rfc4122AndCombGenerator) NewCombV1() (UUID, error) {
 func (g *rfc4122AndCombGenerator) NewCombV4() (UUID, error) {
 	u := UUID{}
 
-	timeNow := g.getEpoch()
+	timeNow := time.Now().UnixNano()
 
 	binary.BigEndian.PutUint16(u[0:], uint16(timeNow>>48))
 	binary.BigEndian.PutUint16(u[2:], uint16(timeNow>>32))

--- a/generator_test.go
+++ b/generator_test.go
@@ -245,7 +245,6 @@ func (s *genTestSuite) TestNewCombV1(c *C) {
 	u1, err := NewCombV1()
 	c.Assert(err, IsNil)
 	c.Assert(u1.Version(), Equals, V1)
-	c.Assert(u1.Variant(), Equals, VariantFuture)
 
 	u2, err := NewCombV1()
 	c.Assert(err, IsNil)
@@ -275,7 +274,7 @@ func (s *genTestSuite) TestNewCombV1FaultyRand(c *C) {
 	}
 	u1, err := g.NewCombV1()
 	c.Assert(err, NotNil)
-	c.Assert(u1, Equals, Nil)
+	c.Assert(u1, Equals, CombUUID(Nil))
 }
 
 func (s *genTestSuite) TestNewCombV1MissingNetworkInterfaces(c *C) {
@@ -302,7 +301,27 @@ func (s *genTestSuite) TestNewCombV1MissingNetInterfacesAndFaultyRand(c *C) {
 	}
 	u1, err := g.NewCombV1()
 	c.Assert(err, NotNil)
-	c.Assert(u1, Equals, Nil)
+	c.Assert(u1, Equals, CombUUID(Nil))
+}
+
+func (s *genTestSuite) TestNewCombV1Time(c *C) {
+	now := time.Unix(0, 0)
+
+	g := &rfc4122AndCombGenerator{
+		epochFunc: func() time.Time {
+			return now
+		},
+		hwAddrFunc: defaultHWAddrFunc,
+		rand:       rand.Reader,
+	}
+
+	u1, err := g.NewCombV1()
+	c.Assert(err, IsNil)
+
+	if err == nil {
+		ut := u1.Time()
+		c.Assert(ut.Unix(), Equals, now.Unix())
+	}
 }
 
 func (s *genTestSuite) TestCombV1OrderedUUID(c *C) {
@@ -331,7 +350,6 @@ func (s *genTestSuite) TestNewCombV4(c *C) {
 	u1, err := NewCombV4()
 	c.Assert(err, IsNil)
 	c.Assert(u1.Version(), Equals, V4)
-	c.Assert(u1.Variant(), Equals, VariantFuture)
 
 	u2, err := NewCombV4()
 	c.Assert(err, IsNil)
@@ -346,7 +364,7 @@ func (s *genTestSuite) TestNewCombV4FaultyRand(c *C) {
 	}
 	u1, err := g.NewCombV4()
 	c.Assert(err, NotNil)
-	c.Assert(u1, Equals, Nil)
+	c.Assert(u1, Equals, CombUUID(Nil))
 }
 
 func (s *genTestSuite) TestNewCombV4PartialRead(c *C) {
@@ -363,7 +381,27 @@ func (s *genTestSuite) TestNewCombV4PartialRead(c *C) {
 	c.Assert(mostlyZeros, Equals, false)
 }
 
-func (s *genTestSuite) TestCombV4OrderedUUIDIn1nsRange(c *C) {
+func (s *genTestSuite) TestNewCombV4Time(c *C) {
+	now := time.Unix(0, 0)
+
+	g := &rfc4122AndCombGenerator{
+		epochFunc: func() time.Time {
+			return now
+		},
+		hwAddrFunc: defaultHWAddrFunc,
+		rand:       rand.Reader,
+	}
+
+	u1, err := g.NewCombV4()
+	c.Assert(err, IsNil)
+
+	if err == nil {
+		ut := u1.Time()
+		c.Assert(ut.Unix(), Equals, now.Unix())
+	}
+}
+
+func (s *genTestSuite) TestCombV4OrderedUUIDIn100nsRange(c *C) {
 	var uuids []string
 	for i := 0; i < c.N; i++ {
 		uuid, err := NewCombV4()
@@ -371,7 +409,7 @@ func (s *genTestSuite) TestCombV4OrderedUUIDIn1nsRange(c *C) {
 			uuids = append(uuids, uuid.String())
 		}
 
-		time.Sleep(1 * time.Nanosecond)
+		time.Sleep(100 * time.Nanosecond)
 	}
 
 	sorted := sort.SliceIsSorted(uuids, func(i, j int) bool {

--- a/generator_test.go
+++ b/generator_test.go
@@ -363,7 +363,7 @@ func (s *genTestSuite) TestNewCombV4PartialRead(c *C) {
 	c.Assert(mostlyZeros, Equals, false)
 }
 
-func (s *genTestSuite) TestCombV4OrderedUUIDIn100nsRange(c *C) {
+func (s *genTestSuite) TestCombV4OrderedUUIDIn1nsRange(c *C) {
 	var uuids []string
 	for i := 0; i < c.N; i++ {
 		uuid, err := NewCombV4()
@@ -371,7 +371,7 @@ func (s *genTestSuite) TestCombV4OrderedUUIDIn100nsRange(c *C) {
 			uuids = append(uuids, uuid.String())
 		}
 
-		time.Sleep(100 * time.Nanosecond)
+		time.Sleep(1 * time.Nanosecond)
 	}
 
 	sorted := sort.SliceIsSorted(uuids, func(i, j int) bool {

--- a/sql.go
+++ b/sql.go
@@ -49,6 +49,17 @@ func (u *UUID) Scan(src interface{}) error {
 	return fmt.Errorf("uuid: cannot convert %T to UUID", src)
 }
 
+// Value implements the driver.Valuer interface.
+func (u CombUUID) Value() (driver.Value, error) {
+	return u.String(), nil
+}
+
+// Scan implements the sql.Scanner interface.
+func (u *CombUUID) Scan(src interface{}) error {
+	var uuid = UUID(*u)
+	return uuid.Scan(src)
+}
+
 // NullUUID can be used with the standard sql package to represent a
 // UUID value that can be NULL in the database
 type NullUUID struct {

--- a/uuid.go
+++ b/uuid.go
@@ -84,6 +84,11 @@ func Equal(u1 UUID, u2 UUID) bool {
 	return bytes.Equal(u1[:], u2[:])
 }
 
+// Equal returns true if this uuid and other uuid equals, otherwise false
+func (u UUID) Equal(other UUID) bool {
+	return bytes.Equal(u[:], other[:])
+}
+
 // Version returns algorithm version used to generate UUID.
 func (u UUID) Version() byte {
 	return u[6] >> 4

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -51,6 +51,9 @@ func (s *testSuite) TestString(c *C) {
 func (s *testSuite) TestEqual(c *C) {
 	c.Assert(Equal(NamespaceDNS, NamespaceDNS), Equals, true)
 	c.Assert(Equal(NamespaceDNS, NamespaceURL), Equals, false)
+
+	c.Assert(NamespaceDNS.Equal(NamespaceDNS), Equals, true)
+	c.Assert(NamespaceDNS.Equal(NamespaceURL), Equals, false)
 }
 
 func (s *testSuite) TestVersion(c *C) {


### PR DESCRIPTION
Add COMB (Combined-Time) UUID for V1 and V4.

COMB UUID with ordered-time could optimize insert performance and keep data in ordered state.

[https://www.percona.com/blog/2014/12/19/store-uuid-optimized-way/](url)